### PR TITLE
Change scipy dependency to fix breakage in spec2vec / gensim

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 python = ">=3.10,<3.13"
 numba = "^0.60.0"
 numpy = ">1.24"
-scipy = "^1.14.1"
+scipy = "<1.14.0"
 
 [tool.poetry.group.dev.dependencies]
 decorator = "^5.1.1"


### PR DESCRIPTION
Installing sparsestack (`scipy^1.14.1`) will lead to a dependency break for spec2vec/matchms with gensim:

`gensim 4.3.3 requires scipy<1.14.0,>=1.7.0, but you have scipy 1.14.1 which is incompatible.`